### PR TITLE
Removed exit() calls in extract so that it can be used within plugins from the manager

### DIFF
--- a/Gitify
+++ b/Gitify
@@ -88,7 +88,11 @@ switch ($command) {
 
         require_once dirname(__FILE__) . '/src/GitifyExtract.class.php';
         $runner = new GitifyExtract();
-        $runner->run($project);
+        $success = $runner->run($project);
+        if(!$success) {
+            // something went wrong in run execution
+            exit(1);
+        }
 
         break;
 

--- a/src/GitifyExtract.class.php
+++ b/src/GitifyExtract.class.php
@@ -17,12 +17,12 @@ class GitifyExtract extends Gitify
     {
         if (!file_exists($project['path'] . 'config.core.php')) {
             echo "Error: there does not seem to be a MODX install present here.\n";
-            exit(1);
+            return false;
         }
 
         if (!$this->loadMODX($project['path'])) {
             echo "Error: Could not load the MODX API\n";
-            exit(1);
+            return false;
         }
 
         foreach ($project['data'] as $folder => $type) {
@@ -44,9 +44,8 @@ class GitifyExtract extends Gitify
                     break;
             }
         }
-
         echo "Done!\n";
-        exit(0);
+        return true;
     }
 
     /**


### PR DESCRIPTION
I made a plugin to run gitify extract whenever a form is saved within the manager (so gitify would always be in sync). However, with the exit() calls, code execution is stopped and the manager can't complete saving elements. This moves the exits out into the main Gitify file, which should be safe. 
