### PR TITLE
Fix of PHP error if no type folder exists inside Gitify data directory

### DIFF
--- a/src/GitifyBuild.class.php
+++ b/src/GitifyBuild.class.php
@@ -195,8 +195,14 @@ class GitifyBuild extends Gitify
     public function buildObjects($folder, $type)
     {
         $folder = getcwd() . DIRECTORY_SEPARATOR . $folder;
-        $directory = new DirectoryIterator($folder);
 
+        if (!file_exists($folder)) {
+            $this->echoInfo('Skipping : no content folder found');
+
+            return;
+        }
+
+        $directory = new DirectoryIterator($folder);
 
         foreach ($directory as $file) {
             /** @var SplFileInfo $file */


### PR DESCRIPTION
Prevent PHP error if there is no type folder (specified in .gitify config file) inside data directory.

E.g. categories directory for clean MODX install
