### PR TITLE
Correct transliteration for unicode character in filename

### DIFF
--- a/src/GitifyExtract.class.php
+++ b/src/GitifyExtract.class.php
@@ -122,6 +122,8 @@ class GitifyExtract extends Gitify
             $file = $this->generate($object, $options);
             $path = empty($pk) ? $object->getPrimaryKey() : $object->get($pk);
 
+            $path = iconv('UTF-8', 'ISO-8859-9//TRANSLIT', $path);
+
             $ext = (isset($options['extension'])) ? $options['extension'] : '.yaml';
             $fn = $folder . DIRECTORY_SEPARATOR . $path . $ext;
             $after[] = $fn;


### PR DESCRIPTION
Prevent weird characters in filenames when extracting for e.g. Templates with diacritics characters in name.

Maybe this is only Windows issue. Please test it on unix environment.
