### PR TITLE
Fixed extract command for work with dashboards and widgets

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -244,8 +244,12 @@ class ExtractCommand extends BaseCommand
         // If there's a dedicated content field, we put that below the yaml for easier managing,
         // unless the object is a modStaticResource, calling getContent on a static resource can break the
         // extracting because it tries to return the (possibly binary) file.
+        // the same problem with modDashboardWidget, it's have custom getContent method
         $content = '';
-        if (method_exists($object, 'getContent') && !($object instanceof \modStaticResource)) {
+        if (method_exists($object, 'getContent')
+            && !($object instanceof \modStaticResource)
+            && !($object instanceof \modDashboardWidget)
+        ) {
             $content = $object->getContent();
 
             if (!empty($content)) {


### PR DESCRIPTION
By default Gitify use getContent method from extracting object, but in widget class getContent implemented by other way. 