### PR TITLE
Add new `Gitify backup` command to create a quick mysql backup

### DIFF
--- a/Gitify
+++ b/Gitify
@@ -24,6 +24,7 @@ use modmore\Gitify\Command\ExtractCommand;
 use modmore\Gitify\Command\InitCommand;
 use modmore\Gitify\Command\InstallModxCommand;
 use modmore\Gitify\Command\InstallPackageCommand;
+use modmore\Gitify\Command\RestoreCommand;
 
 $application = new Gitify('Gitify', '0.6.0');
 $application->add(new InitCommand);
@@ -32,4 +33,5 @@ $application->add(new ExtractCommand);
 $application->add(new InstallModxCommand);
 $application->add(new InstallPackageCommand);
 $application->add(new BackupCommand);
+$application->add(new RestoreCommand);
 $application->run();

--- a/Gitify
+++ b/Gitify
@@ -18,9 +18,10 @@ if (!defined('GITIFY_WORKING_DIR')) {
 }
 
 use modmore\Gitify\Gitify;
-use modmore\Gitify\Command\InitCommand;
+use modmore\Gitify\Command\BackupCommand;
 use modmore\Gitify\Command\BuildCommand;
 use modmore\Gitify\Command\ExtractCommand;
+use modmore\Gitify\Command\InitCommand;
 use modmore\Gitify\Command\InstallModxCommand;
 use modmore\Gitify\Command\InstallPackageCommand;
 
@@ -30,4 +31,5 @@ $application->add(new BuildCommand);
 $application->add(new ExtractCommand);
 $application->add(new InstallModxCommand);
 $application->add(new InstallPackageCommand);
+$application->add(new BackupCommand);
 $application->run();

--- a/src/Command/BackupCommand.php
+++ b/src/Command/BackupCommand.php
@@ -1,0 +1,101 @@
+<?php
+namespace modmore\Gitify\Command;
+
+use modmore\Gitify\Gitify;
+use modmore\Gitify\BaseCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Class BackupCommand
+ *
+ * Used for creating a quick timestamped mysql dump of the database.
+ *
+ * @package modmore\Gitify\Command
+ */
+class BackupCommand extends BaseCommand
+{
+    public $loadConfig = true;
+    public $loadMODX = true;
+
+    protected function configure()
+    {
+        $this
+            ->setName('backup')
+            ->setDescription('Generates the .gitify file to set up a new Gitify project. Optionally installs MODX as well.')
+
+            ->addOption(
+                'name',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Optionally the name of the backup file, useful for milestone backups.'
+            )
+        ;
+    }
+
+    /**
+     * Runs the command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /**
+         * @var $database_type
+         * @var $database_server
+         * @var $database_user
+         * @var $database_password
+         * @var $dbase
+         * @var
+         */
+        include MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
+
+        if ($database_type !== 'mysql') {
+            $output->writeln('<error>Sorry, only MySQL is supported as database driver currently.</error>');
+            return 1;
+        }
+
+        // Grab the directory to place the backup
+        $backupDirectory = isset($this->config['backup_directory']) ? $this->config['backup_directory'] : '_backup/';
+        $targetDirectory = GITIFY_WORKING_DIR . $backupDirectory;
+
+        // Make sure the directory exists
+        if (!is_dir($targetDirectory)) {
+            mkdir($targetDirectory);
+            if (!is_dir($targetDirectory)) {
+                $output->writeln('<error>Could not create {$backupDirectory} folder</error>');
+                return 1;
+            }
+        }
+
+        // Compute the name
+        $file = $input->getOption('name');
+        if (!empty($file)) {
+            $file = $this->modx->filterPathSegment($file);
+        }
+        else {
+            $file = date(DATE_ATOM);
+        }
+        if (substr($file, -4) != '.sql') {
+            $file .= '.sql';
+        }
+
+        // Full target directory and file
+        $targetFile = $targetDirectory . $file;
+
+        if (file_exists($targetFile)) {
+            $output->writeln('<error>A file with the name {$file} already exists in {$backupDirectory}.</error>');
+            return 1;
+        }
+
+        $output->writeln('Writing database backup to <info>' . $file . '</info>...');
+        exec("mysqldump -u {$database_user} -p{$database_password} {$dbase} > {$targetFile} ");
+        return 0;
+    }
+}

--- a/src/Command/BackupCommand.php
+++ b/src/Command/BackupCommand.php
@@ -4,6 +4,7 @@ namespace modmore\Gitify\Command;
 use modmore\Gitify\Gitify;
 use modmore\Gitify\BaseCommand;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,13 +27,12 @@ class BackupCommand extends BaseCommand
     {
         $this
             ->setName('backup')
-            ->setDescription('Generates the .gitify file to set up a new Gitify project. Optionally installs MODX as well.')
+            ->setDescription('Creates a quick backup of the entire MODX database. Runs automatically when using `Gitify build --force`, but can also be used manually.')
 
-            ->addOption(
+            ->addArgument(
                 'name',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Optionally the name of the backup file, useful for milestone backups.'
+                InputArgument::OPTIONAL,
+                'Optionally the name of the backup file, useful for milestone backups. If not specified the file name will be a full timestamp.'
             )
         ;
     }
@@ -75,7 +75,7 @@ class BackupCommand extends BaseCommand
         }
 
         // Compute the name
-        $file = $input->getOption('name');
+        $file = $input->getArgument('name');
         if (!empty($file)) {
             $file = $this->modx->filterPathSegment($file);
         }

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -109,9 +109,6 @@ class BuildCommand extends BaseCommand
      */
     public function buildContent($folder, $options)
     {
-        $folder = getcwd() . DIRECTORY_SEPARATOR . $folder;
-        $directory = new \DirectoryIterator($folder);
-
         if ($this->input->getOption('force')) {
             $this->output->writeln('Forcing build, removing prior Resources...');
             $this->modx->removeCollection('modResource', array());
@@ -124,6 +121,8 @@ class BuildCommand extends BaseCommand
             }
         }
 
+        $folder = getcwd() . DIRECTORY_SEPARATOR . $folder;
+        $directory = new \DirectoryIterator($folder);
         foreach ($directory as $path => $info) {
             /** @var \SplFileInfo $info */
             $name = $info->getBasename();

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -3,6 +3,7 @@ namespace modmore\Gitify\Command;
 
 use modmore\Gitify\BaseCommand;
 use modmore\Gitify\Gitify;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -39,6 +40,13 @@ class BuildCommand extends BaseCommand
                 InputOption::VALUE_NONE,
                 'When specified, all existing content will be removed before rebuilding. Can be useful when having dealt with complex conflicts.'
             )
+
+            ->addOption(
+                'no-backup',
+                null,
+                InputOption::VALUE_NONE,
+                'When using the --force attribute, Gitify will automatically create a full database backup first. Specify --no-backup to skip creating the backup, at your own risk.'
+            )
         ;
     }
 
@@ -51,6 +59,18 @@ class BuildCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+
+        if ($input->getOption('force') && !$input->getOption('no-backup')) {
+            $backup = $this->getApplication()->find('backup');
+            $arguments = array(
+                'command' => 'backup'
+            );
+            $backupInput = new ArrayInput($arguments);
+            if ($backup->run($backupInput, $output) !== 0) {
+                $output->writeln('<error>Could not write backup. Try building without --force, or specify the --no-backup flag to force build without writing a backup.');
+                return 1;
+            }
+        }
         foreach ($this->config['data'] as $folder => $type) {
             switch (true) {
                 case (!empty($type['type']) && $type['type'] == 'content'):

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -75,6 +75,17 @@ class InitCommand extends BaseCommand
         if (empty($directory)) $directory = '_data/';
         $directory = trim($directory, '/') . '/';
         $data['data_directory'] = $directory;
+        mkdir($directory);
+
+        /**
+         * Ask the user for a backup directory to store database backups in
+         */
+        $question = new Question('Please enter the name of the backup directory (defaults to _db/): ', '_db');
+        $directory = $helper->ask($input, $output, $question);
+        if (empty($directory)) $directory = '_db/';
+        $directory = trim($directory, '/') . '/';
+        $data['backup_directory'] = $directory;
+        mkdir($directory);
 
         /**
          * Ask if we want to include some default data types

--- a/src/Command/RestoreCommand.php
+++ b/src/Command/RestoreCommand.php
@@ -1,0 +1,137 @@
+<?php
+namespace modmore\Gitify\Command;
+
+use modmore\Gitify\Gitify;
+use modmore\Gitify\BaseCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Class RestoreCommand
+ *
+ * Used for restoring database backups created with `Gitify backup` (or possibly any other type of mysql backup).
+ *
+ * @package modmore\Gitify\Command
+ */
+class RestoreCommand extends BaseCommand
+{
+    public $loadConfig = true;
+    public $loadMODX = true;
+
+    protected function configure()
+    {
+        $this
+            ->setName('restore')
+            ->setDescription('Restores the MODX database from a database dump created by `Gitify backup`')
+
+            ->addArgument(
+                'file',
+                InputArgument::OPTIONAL,
+                'The file name of the backup to restore; if left empty you will be provided a list of available backups. Specify "last" to use the last backup, based on the file modification time.'
+            )
+        ;
+    }
+
+    /**
+     * Runs the command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /**
+         * @var $database_type
+         * @var $database_server
+         * @var $database_user
+         * @var $database_password
+         * @var $dbase
+         * @var
+         */
+        include MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
+
+        if ($database_type !== 'mysql') {
+            $output->writeln('<error>Sorry, only MySQL is supported as database driver currently.</error>');
+            return 1;
+        }
+
+        // Grab the directory the backups are in
+        $backupDirectory = isset($this->config['backup_directory']) ? $this->config['backup_directory'] : '_backup/';
+        $targetDirectory = GITIFY_WORKING_DIR . $backupDirectory;
+
+        // Make sure the directory exists
+        if (!is_dir($targetDirectory) || !is_readable($targetDirectory)) {
+            $output->writeln('<error>Cannot read the {$backupDirectory} folder.</error>');
+            return 1;
+        }
+
+        // Grab available backups
+        $backups = array();
+        $directory = new \DirectoryIterator($targetDirectory);
+        foreach ($directory as $path => $info) {
+            /** @var \SplFileInfo $info */
+            $name = $info->getBasename();
+            // Ignore dotfiles/folders
+            if (substr($name, 0, 1) == '.') {
+                continue;
+            }
+
+            if ($info->isDir()) {
+                continue;
+            }
+
+            $modified = $info->getMTime();
+
+            $backups[$name] = array(
+                'name' => $name,
+                'last_modified' => $modified
+            );
+        }
+
+        uasort($backups, function($a, $b) {
+            if ($a['last_modified'] === $b['last_modified']) {
+                return 0;
+            }
+            return ($a['last_modified'] < $b['last_modified']) ? 1 : -1;
+        });
+
+        $file = false;
+        $fileInput = $input->getArgument('file');
+        if (!empty($fileInput)) {
+            if (array_key_exists($fileInput, $backups)) {
+                $file = $fileInput;
+            }
+            elseif (array_key_exists($fileInput . '.sql', $backups)) {
+                $file = $fileInput . '.sql';
+            }
+            elseif ($fileInput === 'last') {
+                $file = reset(array_keys($backups));
+            }
+
+        }
+
+        if (!$file) {
+            $helper = $this->getHelper('question');
+            $question = new ChoiceQuestion(
+                'Please choose the backup to restore (defaults to option 0): ',
+                array_keys($backups),
+                0
+            );
+            $question->setErrorMessage('There is no backup with the name %s.');
+
+            $file = $helper->ask($input, $output, $question);
+        }
+
+        $output->writeln('Restoring from backup <info>' . $file . '</info>...');
+
+        exec("mysql -u {$database_user} -p{$database_password} {$dbase} < {$targetDirectory}{$file}");
+        return 0;
+    }
+}


### PR DESCRIPTION
Add new `Gitify backup` command to create a quick mysql backup. This isalso done automatically when doing a `Gitify build --force`.

To do:

- [x] Add `Gitify restore` to quickly restore a backup
- [x] Documentation