### PR TITLE
skip empty tvs

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -370,6 +370,7 @@ class ExtractCommand extends BaseCommand
                 $templateVars = $object->getTemplateVars();
                 foreach ($templateVars as $tv) {
                     /** @var \modTemplateVar $tv */
+                    if (empty($tv->get('value'))) continue;
                     $tvs[$tv->get('name')] = $tv->get('value');
                 }
                 ksort($tvs);


### PR DESCRIPTION
From my perspective there is no need to add empty TV values into the extracted content files. This is useful because now after adding a new TV, not every single resource file changes - only those with a value.