### PR TITLE
Fix move command of unziped content of release package to parent folder

### DIFF
--- a/src/Command/InstallModxCommand.php
+++ b/src/Command/InstallModxCommand.php
@@ -106,7 +106,7 @@ class InstallModxCommand extends BaseCommand
 
         $this->output->writeln("Moving unzipped files out of temporary directory...");
 
-        exec("mv ./{$insideFolder}* .;");
+        exec("mv ./{$insideFolder}* ./");
         exec("rm -r ./{$insideFolder}");
 
         if (!unlink('modx.zip')) {


### PR DESCRIPTION
Maybe this is problem only on Windows but this correction shouldn't
be problem for other OS.