### PR TITLE
Change backup default filename to be working on Windows

### DIFF
--- a/src/Command/BackupCommand.php
+++ b/src/Command/BackupCommand.php
@@ -77,7 +77,7 @@ class BackupCommand extends BaseCommand
         if (!empty($file)) {
             $file = $this->modx->filterPathSegment($file);
         } else {
-            $file = date(DATE_ATOM);
+            $file = strftime('%Y-%m-%d-%H%M%S-%z');
         }
         if (substr($file, -4) != '.sql') {
             $file .= '.sql';


### PR DESCRIPTION
`date(DATE_ATOM)` can't be use as filename on Windows because of used `:` character