### PR TITLE
Fix Init command when Data and/or Backup directories already exists and are not empty

### DIFF
--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -75,7 +75,10 @@ class InitCommand extends BaseCommand
         if (empty($directory)) $directory = '_data/';
         $directory = trim($directory, '/') . '/';
         $data['data_directory'] = $directory;
-        mkdir($directory);
+
+        if ( ! file_exists($directory)) {
+            mkdir($directory);
+        }
 
         /**
          * Ask the user for a backup directory to store database backups in
@@ -85,7 +88,10 @@ class InitCommand extends BaseCommand
         if (empty($directory)) $directory = '_backup/';
         $directory = trim($directory, '/') . '/';
         $data['backup_directory'] = $directory;
-        mkdir($directory);
+
+        if ( ! file_exists($directory)) {
+            mkdir($directory);
+        }
 
         /**
          * Ask if we want to include some default data types


### PR DESCRIPTION
It would be nice to have those two code blocks (getting of data and backup directory) in one cycle, because both are almost the same, there are only small differences.

Currently following only the original "habit" :)