### PR TITLE
Exclude invalid path in modx zip which cause extraction error on some systems (cf. Docker/Alpine)

### DIFF
--- a/src/Command/InstallModxCommand.php
+++ b/src/Command/InstallModxCommand.php
@@ -96,7 +96,7 @@ class InstallModxCommand extends BaseCommand
         }
 
         $this->output->writeln("Extracting zip...");
-        exec('unzip modx.zip');
+        exec('unzip modx.zip -x "*/./"');
 
         $insideFolder = exec('ls -F | grep "modx-" | head -1');
         if(empty($insideFolder) || $insideFolder == '/') {


### PR DESCRIPTION
The invalid path is the first one : `modx-2.3.5-pl/./`, this path cause an error while unzipping : `unzip: can't create directory 'modx-2.3.5-pl/./': File exists`