### PR TITLE
Remove PHP Warning on mkdir()

### DIFF
--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -75,7 +75,7 @@ class InitCommand extends BaseCommand
         if (empty($directory)) $directory = '_data/';
         $directory = trim($directory, '/') . '/';
         $data['data_directory'] = $directory;
-        mkdir($directory);
+        if (!file_exists($directory)) mkdir($directory);
 
         /**
          * Ask the user for a backup directory to store database backups in
@@ -85,7 +85,7 @@ class InitCommand extends BaseCommand
         if (empty($directory)) $directory = '_backup/';
         $directory = trim($directory, '/') . '/';
         $data['backup_directory'] = $directory;
-        mkdir($directory);
+        if (!file_exists($directory)) mkdir($directory);
 
         /**
          * Ask if we want to include some default data types

--- a/src/Command/InstallModxCommand.php
+++ b/src/Command/InstallModxCommand.php
@@ -59,7 +59,8 @@ class InstallModxCommand extends BaseCommand
         $output->writeln("Running MODX Setup...");
 
         // Actually run the CLI setup
-        exec("php -d date.timezone={$tz} {$wd}setup/index.php --installmode=new --config={$config}");
+        exec("php -d date.timezone={$tz} {$wd}setup/index.php --installmode=new --config={$config}", $setupOutput);
+        $output->writeln("Setup:: {$setupOutput[0]}");
 
         // Try to clean up the config file
         if (!unlink($config))

--- a/src/Command/InstallModxCommand.php
+++ b/src/Command/InstallModxCommand.php
@@ -96,7 +96,7 @@ class InstallModxCommand extends BaseCommand
         }
 
         $this->output->writeln("Extracting zip...");
-        exec('unzip modx.zip');
+        exec('unzip modx.zip -x "*/./"');
 
         $insideFolder = exec('ls -F | grep "modx-" | head -1');
         if(empty($insideFolder) || $insideFolder == '/') {


### PR DESCRIPTION
Remove `PHP Warning: mkdir(): File exists` when overwriting previous Gitify installation with the same data/backup directories.