### PR TITLE
Cached downloads of modx

### DIFF
--- a/application.php
+++ b/application.php
@@ -27,17 +27,37 @@ if (!defined('GITIFY_WORKING_DIR')) {
 }
 
 /**
+ * Specify the user home directory, for save cache folder of gitify
+ */
+if (!defined('USER_HOME_DIR')) {
+    $home = rtrim(getenv('HOME'), DIRECTORY_SEPARATOR);
+    if (!$home) {
+        $home = rtrim($_SERVER['HOME'], DIRECTORY_SEPARATOR);
+    }
+    if (!$home && isset($_SERVER['HOMEDRIVE']) && isset($_SERVER['HOMEPATH'])) {
+        // compatibility to Windows
+        $home = rtrim($_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'], DIRECTORY_SEPARATOR);
+    }
+    if (!$home) {
+        // fallback to working directory, if home directory can not be determined
+        $home = rtrim(GITIFY_WORKING_DIR, DIRECTORY_SEPARATOR);
+    }
+    define('USER_HOME_DIR', $home . DIRECTORY_SEPARATOR);
+}
+
+/**
  * Load all the commands and create the Gitify instance
  */
-use modmore\Gitify\Gitify;
 use modmore\Gitify\Command\BackupCommand;
 use modmore\Gitify\Command\BuildCommand;
+use modmore\Gitify\Command\ClearCacheCommand;
 use modmore\Gitify\Command\ExtractCommand;
 use modmore\Gitify\Command\InitCommand;
 use modmore\Gitify\Command\InstallModxCommand;
-use modmore\Gitify\Command\UpgradeModxCommand;
 use modmore\Gitify\Command\InstallPackageCommand;
 use modmore\Gitify\Command\RestoreCommand;
+use modmore\Gitify\Command\UpgradeModxCommand;
+use modmore\Gitify\Gitify;
 
 $application = new Gitify('Gitify', '0.10.0');
 $application->add(new InitCommand);
@@ -48,6 +68,7 @@ $application->add(new UpgradeModxCommand);
 $application->add(new InstallPackageCommand);
 $application->add(new BackupCommand);
 $application->add(new RestoreCommand);
+$application->add(new ClearCacheCommand());
 /**
  * We return it so the CLI controller in /Gitify can run it, or for other integrations to
  * work with the Gitify api directly.

--- a/application.php
+++ b/application.php
@@ -29,7 +29,7 @@ if (!defined('GITIFY_WORKING_DIR')) {
 /**
  * Specify the user home directory, for save cache folder of gitify
  */
-if (!defined('USER_HOME_DIR')) {
+if (!defined('GITIFY_CACHE_DIR')) {
     $home = rtrim(getenv('HOME'), DIRECTORY_SEPARATOR);
     if (!$home) {
         $home = rtrim($_SERVER['HOME'], DIRECTORY_SEPARATOR);
@@ -42,7 +42,7 @@ if (!defined('USER_HOME_DIR')) {
         // fallback to working directory, if home directory can not be determined
         $home = rtrim(GITIFY_WORKING_DIR, DIRECTORY_SEPARATOR);
     }
-    define('USER_HOME_DIR', $home . DIRECTORY_SEPARATOR);
+    define('GITIFY_CACHE_DIR', join(DIRECTORY_SEPARATOR, [$home, '.gitify', '']));
 }
 
 /**
@@ -68,7 +68,7 @@ $application->add(new UpgradeModxCommand);
 $application->add(new InstallPackageCommand);
 $application->add(new BackupCommand);
 $application->add(new RestoreCommand);
-$application->add(new ClearCacheCommand());
+$application->add(new ClearCacheCommand);
 /**
  * We return it so the CLI controller in /Gitify can run it, or for other integrations to
  * work with the Gitify api directly.

--- a/composer.lock
+++ b/composer.lock
@@ -8,17 +8,17 @@
     "packages": [
         {
             "name": "symfony/console",
-            "version": "v2.6.10",
+            "version": "v2.6.11",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "042107bc202845086739414339e551fbe81293d7"
+                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/042107bc202845086739414339e551fbe81293d7",
-                "reference": "042107bc202845086739414339e551fbe81293d7",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/0e5e18ae09d3f5c06367759be940e9ed3f568359",
+                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359",
                 "shasum": ""
             },
             "require": {
@@ -62,11 +62,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-13 09:09:47"
+            "time": "2015-07-26 09:08:40"
         },
         {
             "name": "symfony/process",
-            "version": "v2.6.10",
+            "version": "v2.6.11",
             "target-dir": "Symfony/Component/Process",
             "source": {
                 "type": "git",
@@ -116,17 +116,17 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.10",
+            "version": "v2.6.11",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "446353cc05339e676fb57e35232d2bfd055a47cd"
+                "reference": "c044d1744b8e91aaaa0d9bac683ab87ec7cbf359"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/446353cc05339e676fb57e35232d2bfd055a47cd",
-                "reference": "446353cc05339e676fb57e35232d2bfd055a47cd",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/c044d1744b8e91aaaa0d9bac683ab87ec7cbf359",
+                "reference": "c044d1744b8e91aaaa0d9bac683ab87ec7cbf359",
                 "shasum": ""
             },
             "require": {
@@ -162,7 +162,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-30 16:10:16"
+            "time": "2015-07-26 08:59:42"
         }
     ],
     "packages-dev": [
@@ -222,16 +222,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.1.8",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6044546998c7627ab997501a3d0db972b3db9790"
+                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6044546998c7627ab997501a3d0db972b3db9790",
-                "reference": "6044546998c7627ab997501a3d0db972b3db9790",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef1ca6835468857944d5c3b48fa503d5554cff2f",
+                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f",
                 "shasum": ""
             },
             "require": {
@@ -239,7 +239,7 @@
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "~1.0",
+                "sebastian/environment": "^1.3.2",
                 "sebastian/version": "~1.0"
             },
             "require-dev": {
@@ -254,7 +254,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -280,7 +280,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-07-13 11:25:58"
+            "time": "2015-09-14 06:51:16"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -370,16 +370,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d"
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/83fe1bdc5d47658b727595c14da140da92b3d66d",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
                 "shasum": ""
             },
             "require": {
@@ -407,20 +407,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-13 07:35:30"
+            "time": "2015-06-21 08:01:12"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.3",
+            "version": "1.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "7a9b0969488c3c54fd62b4d504b3ec758fd005d9"
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/7a9b0969488c3c54fd62b4d504b3ec758fd005d9",
-                "reference": "7a9b0969488c3c54fd62b4d504b3ec758fd005d9",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
                 "shasum": ""
             },
             "require": {
@@ -456,7 +456,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-06-19 03:43:16"
+            "time": "2015-09-15 10:49:45"
         },
         {
             "name": "phpunit/phpunit",
@@ -534,22 +534,23 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.5",
+            "version": "2.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "1c330b1b6e1ea8fd15f2fbea46770576e366855c"
+                "reference": "5e2645ad49d196e020b85598d7c97e482725786a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/1c330b1b6e1ea8fd15f2fbea46770576e366855c",
-                "reference": "1c330b1b6e1ea8fd15f2fbea46770576e366855c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5e2645ad49d196e020b85598d7c97e482725786a",
+                "reference": "5e2645ad49d196e020b85598d7c97e482725786a",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "~1.0,>=1.0.2",
+                "doctrine/instantiator": "^1.0.2",
                 "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2"
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -585,20 +586,20 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-07-04 05:41:32"
+            "time": "2015-08-19 09:14:08"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e"
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dd8869519a225f7f2b9eb663e225298fade819e",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
                 "shasum": ""
             },
             "require": {
@@ -612,7 +613,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -649,7 +650,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-01-29 16:28:08"
+            "time": "2015-07-26 15:48:44"
         },
         {
             "name": "sebastian/diff",
@@ -705,16 +706,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.2.2",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e"
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5a8c7d31914337b69923db26c4221b81ff5a196e",
-                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
                 "shasum": ""
             },
             "require": {
@@ -751,20 +752,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-01-01 10:01:08"
+            "time": "2015-08-03 06:14:51"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "84839970d05254c73cde183a721c7af13aede943"
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/84839970d05254c73cde183a721c7af13aede943",
-                "reference": "84839970d05254c73cde183a721c7af13aede943",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
                 "shasum": ""
             },
             "require": {
@@ -817,20 +818,20 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-01-27 07:23:06"
+            "time": "2015-06-21 07:55:53"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252"
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/3989662bbb30a29d20d9faa04a846af79b276252",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
                 "shasum": ""
             },
             "require": {
@@ -870,7 +871,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-01-24 09:48:32"
+            "time": "2015-06-21 08:04:50"
         },
         {
             "name": "sebastian/version",

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace modmore\Gitify\Command;
 
 use modmore\Gitify\BaseCommand;

--- a/src/Command/ClearCacheCommand.php
+++ b/src/Command/ClearCacheCommand.php
@@ -8,6 +8,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ClearCacheCommand extends BaseCommand
 {
+    public $loadConfig = false;
+    public $loadMODX = false;
+
     protected function configure()
     {
         $this
@@ -18,6 +21,9 @@ class ClearCacheCommand extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
+        if (file_exists(GITIFY_CACHE_DIR)) {
+            exec("rm -rf " . GITIFY_CACHE_DIR);
+            $output->writeln('All caches cleared.');
+        }
     }
 }

--- a/src/Command/ClearCacheCommang.php
+++ b/src/Command/ClearCacheCommang.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace modmore\Gitify\Command;
+
+use modmore\Gitify\BaseCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ClearCacheCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('clearcache')
+            ->setDescription('Clears gitify\'s internal package cache.')
+            ->setAliases(['clear-cache']);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+    }
+}

--- a/src/Command/InstallModxCommand.php
+++ b/src/Command/InstallModxCommand.php
@@ -5,6 +5,7 @@ use modmore\Gitify\BaseCommand;
 use modmore\Gitify\Mixins\DownloadModx;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
@@ -32,6 +33,12 @@ class InstallModxCommand extends BaseCommand
                 'version',
                 InputArgument::OPTIONAL,
                 'The version of MODX to install, in the format 2.3.2-pl. Leave empty or specify "latest" to install the last stable release.'
+            )
+            ->addOption(
+                'download',
+                'd',
+                InputOption::VALUE_NONE,
+                'Download and install MODX even package exists in cache folder. Forced download'
             );
     }
 
@@ -45,7 +52,9 @@ class InstallModxCommand extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $version = $this->input->getArgument('version');
-        if (!$this->download($version)) {
+        $forced = $this->input->getOption('download');
+
+        if (!$this->getMODX($version, $forced)) {
             return 1; // exit
         }
 

--- a/src/Command/UpgradeModxCommand.php
+++ b/src/Command/UpgradeModxCommand.php
@@ -6,6 +6,7 @@ use modmore\Gitify\BaseCommand;
 use modmore\Gitify\Mixins\DownloadModx;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpgradeModxCommand extends BaseCommand
@@ -25,13 +26,21 @@ class UpgradeModxCommand extends BaseCommand
                 InputArgument::OPTIONAL,
                 'The version of MODX to upgrade, in the format 2.3.2-pl. Leave empty or specify "latest" to install the last stable release.',
                 'latest'
+            )
+            ->addOption(
+                'download',
+                'd',
+                InputOption::VALUE_NONE,
+                'Download and install MODX even package exists in cache folder. Forced download'
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $version = $this->input->getArgument('version');
-        if (!$this->download($version)) {
+        $forced = $this->input->getOption('download');
+
+        if (!$this->getMODX($version, $forced)) {
             return 1; // exit
         }
 

--- a/src/Mixins/DownloadModx.php
+++ b/src/Mixins/DownloadModx.php
@@ -12,11 +12,9 @@ trait DownloadModx
      */
     protected function download($version = 'latest')
     {
-        if (empty($version) || $version == 'latest') {
-            $url = 'http://modx.com/download/latest/';
-        } else {
-            $url = 'http://modx.com/download/direct/modx-' . $version . '.zip';
-        }
+        $url = empty($version) || $version == 'latest'
+            ? 'http://modx.com/download/latest/'
+            : 'http://modx.com/download/direct/modx-' . $version . '.zip';
 
         $this->output->writeln("Downloading MODX from {$url}...");
         exec('curl -Lo modx.zip ' . $url . ' -#');
@@ -45,6 +43,33 @@ trait DownloadModx
         $this->removeOutdatedArchive();
 
         return true;
+    }
+
+    private function unzip()
+    {
+
+    }
+
+    private function fetchUrl($url)
+    {
+        // пробуем получить прямую линку на файл. если такая версия уже есть, то не скачиваем,
+        // а отдаем из кеша
+        // можно указать флаг и принудительно скачать версию + заменить в кеше
+
+        $ch = curl_init($url);
+        $result = curl_exec($ch);
+
+        print_r($result);
+    }
+
+    private function retriveFromCache($version)
+    {
+
+    }
+
+    private function saveToCache()
+    {
+
     }
 
     private function removeOutdatedArchive()

--- a/src/Mixins/DownloadModx.php
+++ b/src/Mixins/DownloadModx.php
@@ -5,77 +5,115 @@ namespace modmore\Gitify\Mixins;
 trait DownloadModx
 {
     /**
-     * Downloads the latest version of MODX, and puts it into place in the working directory.
+     * Downloads the latest version of MODX or takes from local cache, and puts it into place in the working directory.
      *
      * @param string $version
      * @return bool
      */
-    protected function download($version = 'latest')
+    protected function getMODX($version = 'latest', $download = false)
     {
-        $url = empty($version) || $version == 'latest'
-            ? 'http://modx.com/download/latest/'
-            : 'http://modx.com/download/direct/modx-' . $version . '.zip';
+        $link = $this->fetchUrl($version);
+        $realVersion = basename($link, '.zip');
 
-        $this->output->writeln("Downloading MODX from {$url}...");
-        exec('curl -Lo modx.zip ' . $url . ' -#');
+        if ($download) { // forced download
+            if (!$this->download($link)) {
+                return false;
+            }
+        }
 
-        if (!file_exists('modx.zip')) {
+        $this->retriveFromCache($realVersion);
+
+        return true;
+    }
+
+    /**
+     * Downloads specified package to local storage
+     *
+     * @param $link
+     * @return bool
+     */
+    protected function download($link)
+    {
+        $version = basename($link, '.zip');
+
+        if (!file_exists(GITIFY_CACHE_DIR)) {
+            mkdir(GITIFY_CACHE_DIR);
+        }
+
+        $this->removeOutdatedArchive($version); // remove old files
+
+        $to = GITIFY_CACHE_DIR . basename($link);
+        $this->output->writeln("Downloading MODX {$version}...");
+        exec("curl -Lo $to $link -#");
+
+        if (!file_exists($to)) {
             $this->output->writeln('<error>Error: Could not download the MODX zip</error>');
 
             return false;
         }
 
-        $this->output->writeln("Extracting zip...");
-        exec('unzip modx.zip -x "*/./"');
-
-        $insideFolder = exec('ls -F | grep "modx-" | head -1');
-        if (empty($insideFolder) || $insideFolder == '/') {
-            $this->output->writeln("<error>Error: Could not locate unzipped MODX folder; perhaps the download failed or unzip is not available on your system.</error>");
-
-            return false;
-        }
-
-        $this->output->writeln("Moving unzipped files out of temporary directory...");
-
-        exec("cp -r ./{$insideFolder}* ./");
-        exec("rm -r ./{$insideFolder}");
-
-        $this->removeOutdatedArchive();
+        $this->unzip($to);
 
         return true;
     }
 
-    private function unzip()
+    /**
+     * Unzips package
+     *
+     * @param $package
+     */
+    protected function unzip($package)
     {
+        $this->output->writeln("Extracting package... ");
 
+        $destination = dirname($package);
+        exec("unzip $package -d $destination");
     }
 
-    private function fetchUrl($url)
+    /**
+     * Fetching direct link to file with modx sources
+     *
+     * @param $version
+     * @return mixed
+     */
+    private function fetchUrl($version)
     {
-        // пробуем получить прямую линку на файл. если такая версия уже есть, то не скачиваем,
-        // а отдаем из кеша
-        // можно указать флаг и принудительно скачать версию + заменить в кеше
+        $version = str_replace('modx-', '', $version);
+        $url = empty($version) || $version == 'latest'
+            ? 'http://modx.com/download/latest/'
+            : 'http://modx.com/download/direct/modx-' . $version . '.zip';
 
-        $ch = curl_init($url);
-        $result = curl_exec($ch);
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 0);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+        curl_setopt($ch, CURLOPT_NOBODY, 1);
+        curl_exec($ch);
+        $direct = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+        curl_close($ch);
 
-        print_r($result);
+        return $direct;
     }
 
-    private function retriveFromCache($version)
+    protected function retriveFromCache($version)
     {
+        $path = GITIFY_CACHE_DIR . $version;
 
-    }
-
-    private function saveToCache()
-    {
-
-    }
-
-    private function removeOutdatedArchive()
-    {
-        if (!unlink('modx.zip')) {
-            $this->output->writeln("<info>Note: unable to clean up modx.zip file.</info>");
+        if (!file_exists($path) || !is_dir($path)) {
+            $link = $this->fetchUrl($version);
+            $this->download($link);
         }
+
+        exec("cp -r $path/* ./");
+    }
+
+    protected function removeOutdatedArchive($version)
+    {
+        $folder = GITIFY_CACHE_DIR . $version;
+        $package = $folder . '.zip';
+
+        exec("rm -rf $folder");
+        exec("rm -rf $package");
     }
 }

--- a/src/Mixins/DownloadModx.php
+++ b/src/Mixins/DownloadModx.php
@@ -21,7 +21,7 @@ trait DownloadModx
             }
         }
 
-        $this->retriveFromCache($realVersion);
+        $this->retrieveFromCache($realVersion);
 
         return true;
     }
@@ -96,7 +96,7 @@ trait DownloadModx
         return $direct;
     }
 
-    protected function retriveFromCache($version)
+    protected function retrieveFromCache($version)
     {
         $path = GITIFY_CACHE_DIR . $version;
 


### PR DESCRIPTION
Added support caching downloaded MODX archives for avoid downloading every time.

### How it works. 
Gitify try download package to `/home/user/.gitify` folder and if you try install MODX next time Gitify will check local storage and copy folder with modx from local folder.Also you can force downloading with flag --download (-d)

`Gitify modx:install -d` - forced
`Gitify modx:install` - as usual

Also I've added command clearcache, that remove all cached versions and remove .gitify folder from home directory
`Gitify clearcache`

Please, test on Windows, if somobedy can, because I don't have abbility do it now.