### PR TITLE
Fix backup filename to not contain colon and user previous DATE_ATOM format

### DIFF
--- a/src/Command/BackupCommand.php
+++ b/src/Command/BackupCommand.php
@@ -83,7 +83,7 @@ class BackupCommand extends BaseCommand
         if (!empty($file)) {
             $file = $this->modx->filterPathSegment($file);
         } else {
-            $file = strftime('%Y-%m-%d-%H%M%S-%z');
+            $file = str_replace(':', '', date(DATE_ATOM));
         }
         if (substr($file, -4) != '.sql') {
             $file .= '.sql';


### PR DESCRIPTION
Currently strftime solution makes still problem on Windows platform because of localized output.
And DATE_ATOM format contain colons which are not allowed on Windows NTFS filesystem.
