### PR TITLE
Fix fallback Gitify-Cache-Folder

### DIFF
--- a/application.php
+++ b/application.php
@@ -45,7 +45,7 @@ if (!defined('GITIFY_CACHE_DIR')) {
         // fallback to working directory, if home directory can not be determined
         $home = rtrim(GITIFY_WORKING_DIR, DIRECTORY_SEPARATOR);
     }
-    define('GITIFY_CACHE_DIR', implode(DIRECTORY_SEPARATOR, array($home, '.gitify', '')));
+    define('GITIFY_CACHE_DIR', implode(DIRECTORY_SEPARATOR, array($home, '.gitify-cache', '')));
 }
 
 /**

--- a/application.php
+++ b/application.php
@@ -45,7 +45,7 @@ if (!defined('GITIFY_CACHE_DIR')) {
         // fallback to working directory, if home directory can not be determined
         $home = rtrim(GITIFY_WORKING_DIR, DIRECTORY_SEPARATOR);
     }
-    define('GITIFY_CACHE_DIR', implode(DIRECTORY_SEPARATOR, array($home, '.gitify-cache', '')));
+    define('GITIFY_CACHE_DIR', implode(DIRECTORY_SEPARATOR, array($home, '.gitify', '')));
 }
 
 /**

--- a/src/Command/ClearCacheCommand.php
+++ b/src/Command/ClearCacheCommand.php
@@ -20,7 +20,7 @@ class ClearCacheCommand extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (file_exists(GITIFY_CACHE_DIR)) {
+        if (file_exists(GITIFY_CACHE_DIR) && is_folder(GITIFY_CACHE_DIR)) {
             exec("rm -rf " . GITIFY_CACHE_DIR);
             $output->writeln('Cleared the Gitify cache.');
         }

--- a/src/Command/ClearCacheCommand.php
+++ b/src/Command/ClearCacheCommand.php
@@ -20,7 +20,7 @@ class ClearCacheCommand extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (file_exists(GITIFY_CACHE_DIR) && is_folder(GITIFY_CACHE_DIR)) {
+        if (file_exists(GITIFY_CACHE_DIR)) {
             exec("rm -rf " . GITIFY_CACHE_DIR);
             $output->writeln('Cleared the Gitify cache.');
         }

--- a/src/Mixins/DownloadModx.php
+++ b/src/Mixins/DownloadModx.php
@@ -48,7 +48,7 @@ trait DownloadModx
     {
         $link = $this->fetchUrl($version);
 
-        if (!file_exists(GITIFY_CACHE_DIR) && !is_folder(GITIFY_CACHE_DIR)) {
+        if (!file_exists(GITIFY_CACHE_DIR)) {
             mkdir(GITIFY_CACHE_DIR);
         }
 

--- a/src/Mixins/DownloadModx.php
+++ b/src/Mixins/DownloadModx.php
@@ -48,7 +48,7 @@ trait DownloadModx
     {
         $link = $this->fetchUrl($version);
 
-        if (!file_exists(GITIFY_CACHE_DIR)) {
+        if (!file_exists(GITIFY_CACHE_DIR) && !is_folder(GITIFY_CACHE_DIR)) {
             mkdir(GITIFY_CACHE_DIR);
         }
 


### PR DESCRIPTION
On my server I hit the last if condition. So Gitify tries to set the Gitify-Cache-Folder, named ".gitify", in the Gitify-Working-Dir, which also includes ".gitify" (the file). This failed, because the Gitify-Cache-Folder is the Gitify-Config-File.

This changes the Gitify-Cache-Folder to ".gitify-cache".
