### PR TITLE
Remove slashes from objects primary

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -227,6 +227,7 @@ class ExtractCommand extends BaseCommand
             }
 
             $path = $this->filterPathSegment($path);
+            $path = str_replace('/', '-', $path);
 
             $ext = (isset($options['extension'])) ? $options['extension'] : '.yaml';
             $fn = $folder . DIRECTORY_SEPARATOR . $path . $ext;


### PR DESCRIPTION
### What does it do ?
Filter any slash contained in the $path generated from the primary of an object.

### Why is it needed ?
By default `filterPathSegment()` doesn't strip a `/` from a path, for a good reason (if it would, you could never get a folder structure in MODX).

But in Gitify we can define our primary for each object individually and we could set it to something like `[id,profile,action]` for fc_sets (form customization), where the action would be something like `resource/update`. And this would break Gitify since it would create a path like `/gitify/fc_sets/1.1.resource/update.yaml` which won't work for `Gitify build` commands, since Gitify doesn't handle directories here.

So we need to make sure there's never a slash in our path generated from the primary values for objects.

### Related issue(s)/PR(s)
-