### PR TITLE
[Reqesting Feedback] Stop adding actual content to the file if element is Static

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -301,7 +301,9 @@ class ExtractCommand extends BaseCommand
 
         $out = Gitify::toYAML($data);
 
-        if (!empty($content)) {
+        if (!empty($content) && !empty($data['static'])) {
+            $out .= Gitify::$contentSeparator;
+        } else {
             $out .= Gitify::$contentSeparator . $content;
         }
         return $out;


### PR DESCRIPTION
### What does it do ?
Remove actual content from files if its a static element.

### Why is it needed ?
Having content in 2 different places makes it problematic, once in yaml files, and then in actual static files. If developer forgets to extract and commit the yaml files, its a high chance that the build will mess things up.

### Related issue(s)/PR(s)
n/a

