### PR TITLE
Support OR conditions for content extract

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -109,7 +109,15 @@ class ExtractCommand extends BaseCommand
 
             // Prepare the criteria for this context
             $contextCriteria = ($criteria) ? $criteria : array();
-            $contextCriteria['context_key'] = $contextKey;
+            if (count(array_filter(array_keys($contextCriteria), 'is_string')) > 0) {
+                // associative array => and conditions
+                $contextCriteria['context_key'] = $contextKey;
+            } else {
+                // sequential array => or conidtions
+                foreach ($contextCriteria as $i => $orCondition) {
+                    $contextCriteria[$i]['context_key'] = $contextKey;
+                }
+            }
 
             // Grab the count
             $count = $this->modx->getCount('modResource', $contextCriteria);


### PR DESCRIPTION
### What does it do ?
With this change it's possible to define OR conditions in the `.gitify` config for content extraction. The config could look like this:
```
  contents:
    type: content
    where:
      -
        'context_key:IN': [web,othercontext]
      -
        'OR:parent:IN': [480,510]
```

### Why is it needed ?
Previously the condition for the current extracting context was added like this `$contextCriteria['context_key'] = $contextKey;` - this would destroy the array structure that is needed for the OR condition. With OR conditions you need to add conditions into the sub-arrays.

### Related issue(s)/PR(s)
-

