### PR TITLE
Windows fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.buildpath
+.project
+.settings
 .idea/
 config.core.php
 data/

--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -83,6 +83,10 @@ abstract class BaseCommand extends Command
     public function normalizePath($path)
     {
         $normalized_path = str_replace('\\', Gitify::$directorySeparator, $path);
+        // especially for windows, convert utf8 to local encoding to fix umlauts in filenames
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $normalized_path = utf8_decode($normalized_path);
+        }
 
         return $normalized_path;
     }

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -241,8 +241,11 @@ class BuildCommand extends BaseCommand
             $file = file_get_contents($resource->getRealPath());
 
             // Normalize line-endings to \n to ensure consistency
+            /* this causes file modifications when comparing with afterwards extraction
             $file = str_replace("\r\n", "\n", $file);
             $file = str_replace("\r", "\n", $file);
+            */
+
             // Check if delimiter exists, otherwise add it to avoid WARN in explode()
             // (WARN @ Gitify/src/Command/BuildCommand.php : 246) PHP notice: Undefined offset: 1
             if (strpos($file, Gitify::$contentSeparator) === false) {


### PR DESCRIPTION
### What does it do ?
Exporting german filenames (UTF8) that contain umlauts (öäüß) gets messed up when writing
the files under windows. PHP5 under Windows does not support UTF8.

Also I encountered during my build/extract cycles, that there's a conversion of CR/LF in the gitify
code, that results in changed files after a build/extract - although nothing has changed. This is
inconvenient when comparing against SCM (shows the files modified),

### Why is it needed ?
When exporting filenames, these are not correctly named under windows and are recognized as "new" when diffing against e.g. the SCM.

### Related issue(s)/PR(s)
No PR yet. WDYT?
