### PR TITLE
Allow a phar to be built

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,6 @@
      ],
     "autoload": {
         "psr-4": {"modmore\\Gitify\\":"src/"}
-    }
+    },
+    "bin": ["Gitify"]
 }


### PR DESCRIPTION
### What does it do ?
Allows a phar to be built

### Why is it needed ?
Describe the issue you are solving.

### Related issue(s)/PR(s)
https://github.com/modmore/Gitify/issues/64

Adding the "bin" file allows https://github.com/clue/phar-composer to build a working phar of Gitify