### PR TITLE
Add configurable database host

### DIFF
--- a/src/Command/InstallModxCommand.php
+++ b/src/Command/InstallModxCommand.php
@@ -91,6 +91,10 @@ class InstallModxCommand extends BaseCommand
         $this->output->writeln("Please complete following details to install MODX. Leave empty to use the [default].");
 
         $helper = $this->getHelper('question');
+        
+        $defaultDbHost = 'localhost';
+        $question = new Question("Database Host [{$defaultDbHost}]: ", $defaultDbHost);
+        $dbHost = $helper->ask($this->input, $this->output, $question);
 
         $defaultDbName = basename(GITIFY_WORKING_DIR);
         $question = new Question("Database Name [{$defaultDbName}]: ", $defaultDbName);
@@ -146,7 +150,7 @@ class InstallModxCommand extends BaseCommand
 
         $config = array(
             'database_type' => 'mysql',
-            'database_server' => 'localhost',
+            'database_server' => $dbHost,
             'database' => $dbName,
             'database_user' => $dbUser,
             'database_password' => $dbPass,


### PR DESCRIPTION
### What does it do?
This update adds a new question about database host during the install MODX by gitify.

### Why is it needed?
Currently it uses hardcoded value `localhost`, that obviously not always applicable. Database can be installed on remote server or database can use another host name. In my case, I use docker containers where mysql container has hostname `db`.

### Related issue(s)/PR(s)
No any related issues.
