### PR TITLE
Add ability to specify config file for modx:install

### DIFF
--- a/src/Command/InstallModxCommand.php
+++ b/src/Command/InstallModxCommand.php
@@ -35,6 +35,12 @@ class InstallModxCommand extends BaseCommand
                 'The version of MODX to install, in the format 2.3.2-pl. Leave empty or specify "latest" to install the last stable release.',
                 'latest'
             )
+            ->addArgument(
+                'configFile',
+                InputArgument::OPTIONAL,
+                'Path to XML configuration file. Leave empty to enter configuration details through the command line.',
+                ''
+            )
             ->addOption(
                 'download',
                 'd',
@@ -53,14 +59,20 @@ class InstallModxCommand extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $version = $this->input->getArgument('version');
+        $configFile = $this->input->getArgument('configFile');
         $forced = $this->input->getOption('download');
 
         if (!$this->getMODX($version, $forced)) {
             return 1; // exit
         }
 
-        // Create the XML config
-        $config = $this->createMODXConfig();
+        if ($configFile) {
+            // Load config from file
+            $config = $configFile;
+        } else {
+            // Create the XML config
+            $config = $this->createMODXConfig();
+        }
 
         // Variables for running the setup
         $tz = date_default_timezone_get();


### PR DESCRIPTION
### What does it do ?
This adds the ability to define a physical config file for the modx:install command as follows:

`Gitify modx:install latest /absolute/path/to/config.xml`

It doesn't need to be a .xml file btw, can also be a temp file like /tmp/tmp.CDyHpH4jYP. Just make sure the file has proper read permissions..

### Why is it needed ?
Currently, the required configuration options are passed through the command line during Gitify modx:install. This prevents the installation process from being automated further.

### Related issue(s)/PR(s)
As described in #193.
