### PR TITLE
Enable loading of ServiceClasse when service-option is provided

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -209,7 +209,12 @@ class BuildCommand extends BaseCommand
             $path .= 'model/';
         }
 
-        $this->modx->addPackage($package, $path);
+        if ($options['service']) {
+            $path .= $package . '/';
+            $this->modx->getService($package, $options['service'], $path);
+	} else {
+	    $this->modx->addPackage($package, $path);
+	}
     }
 
     /**

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -321,7 +321,12 @@ class ExtractCommand extends BaseCommand
             $path .= 'model/';
         }
 
-        $this->modx->addPackage($package, $path);
+	if ($options['service']) {
+	    $path .= $package . '/';
+	    $this->modx->getService($package, $options['service'], $path);
+	} else {
+	    $this->modx->addPackage($package, $path);
+	}
     }
 
     /**


### PR DESCRIPTION
### What does it do ?
When a "service" option is provided (the name of the ServiceClass), 
the service should be loaded instead of just the package-class.

### Why is it needed ?
Some extras (like Commerce) use a ServiceClass.

### Related issue(s)/PR(s)
fixes #225 
