### PR TITLE
Converted system based unzip to php's ZipArchive

### DIFF
--- a/src/Mixins/DownloadModx.php
+++ b/src/Mixins/DownloadModx.php
@@ -79,7 +79,14 @@ trait DownloadModx
         $this->output->writeln("Extracting package... ");
 
         $destination = dirname($package);
-        exec("unzip $package -d $destination");
+        $zipArchive = new \ZipArchive();
+        if ($zipArchive->open($package)) {
+            $zipArchive->extractTo($destination);
+            $zipArchive->close();
+            $this->output->writeln("Package extracted successfully.");
+        } else {
+            throw new \Exception("Error opening the package: $package");
+        }
     }
 
     /**


### PR DESCRIPTION
### What does it do ?
I replaced the usage of `exec` for running `unzip` on the system with php's native `ZipArchive` for ModX updates.

### Why is it needed ?
When running the `modx:upgrade` command in linux alpine (and probably other systems as well) I have the following error:

```
unzip: can't create directory 'modx-2.7.0-pl/./': File exists
```

### Related issue(s)/PR(s)
No related issues
