### PR TITLE
Fix feedback when primary object is an array

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -773,6 +773,7 @@ class BuildCommand extends BaseCommand
             $obj = $this->modx->getObject($type['class'], $getPrimary);
             if ($obj instanceof \xPDOObject) {
                 $showPrimary = $this->_getPrimaryKey($type['class'], $primary, $obj->toArray());
+                $showPrimary = (is_array($showPrimary)) ? json_encode($showPrimary) : $showPrimary;
                 if ($obj->remove()) {
                     $this->output->writeln("- <info>Removed orphaned {$type['class']} with primary {$showPrimary}</info>");
                 } else {


### PR DESCRIPTION
### What does it do ?
If object has multiple primary keys, show contents in json array.

### Why is it needed ?
Otherwise, you don't know which orphaned elements are being removed on build..

### Related issue(s)/PR(s)
Fixes #231