### PR TITLE
Improvements to package downloads

### DIFF
--- a/src/Command/InstallPackageCommand.php
+++ b/src/Command/InstallPackageCommand.php
@@ -194,7 +194,7 @@ class InstallPackageCommand extends BaseCommand
             // no matches, skip empty package name
             if ($foundPkg['total'] > 0) {
 
-                $packages [strtolower((string) $foundPkg->name)] = array (
+                $packages[strtolower((string) $foundPkg->name)] = array (
                     'name' => (string) $foundPkg->name,
                     'version' => (string) $foundPkg->version,
                     'location' => (string) $foundPkg->location,

--- a/src/Command/InstallPackageCommand.php
+++ b/src/Command/InstallPackageCommand.php
@@ -185,22 +185,21 @@ class InstallPackageCommand extends BaseCommand
             'supports' => $product_version,
             'signature' => $packageName,
         ));
-        
+
         // when we got a match (non 404), extract package information
         if (!$response->isError()) {
 
-            $foundPkg = simplexml_load_string ( $response->response );
+            $foundPkg = simplexml_load_string ($response->response);
 
             // no matches, skip empty package name
-            if ($foundPackages['total'] > 0) {
+            if ($foundPkg['total'] > 0) {
 
-              $packages [strtolower((string) $foundPkg->name)] = array (
-                  'name' => (string) $foundPkg->name,
-                  'version' => (string) $foundPkg->version,
-                  'location' => (string) $foundPkg->location,
-                  'signature' => (string) $foundPkg->signature
-              );
-              
+                $packages [strtolower((string) $foundPkg->name)] = array (
+                    'name' => (string) $foundPkg->name,
+                    'version' => (string) $foundPkg->version,
+                    'location' => (string) $foundPkg->location,
+                    'signature' => (string) $foundPkg->signature
+                );
             }
         }
 
@@ -210,23 +209,37 @@ class InstallPackageCommand extends BaseCommand
                 'supports' => $product_version,
                 'query' => $packageName,
             ));
-            
+
             // Check for a proper response
             if (!empty($response)) {
-                 
+
                 $foundPackages = simplexml_load_string($response->response);
+                $packageVersions = array();
+
                 // no matches, simply return
                 if ($foundPackages['total'] == 0) {
                     return true;
                 }
-                
+
+                // Create array with available package versions
                 foreach ($foundPackages as $foundPkg) {
-                    $packages[strtolower((string)$foundPkg->name)] = array(
+                    $packageVersions[] = array(
                         'name' => (string)$foundPkg->name,
                         'version' => (string)$foundPkg->version,
                         'location' => (string)$foundPkg->location,
                         'signature' => (string)$foundPkg->signature,
                     );
+                }
+
+                // Use first result, which should be the latest version
+                $package = $packageVersions[0];
+
+                // Verify that the result contains the package name
+                if (strpos($package['signature'], $packageName) !== false) {
+                    $packages[strtolower($package['name'])] = $package;
+                }
+                else {
+                    $this->output->writeln("<error>Couldn't install $packageName because the response did not match the package name.</error>");
                 }
             }
         }
@@ -234,10 +247,10 @@ class InstallPackageCommand extends BaseCommand
         // process found packages
         if (!empty($packages)) {
 
-            $this->output->writeln('Found ' . count($packages) . ' package(s).');
+            //$this->output->writeln('Found ' . count($packages) . ' package(s).');
 
             $helper = $this->getHelper('question');            
-            
+
             // Ensure the exact match is always first
             if (isset($packages[strtolower($packageName)])) {
                 $packages = array($packageName => $packages[strtolower($packageName)]) + $packages;

--- a/src/Command/InstallPackageCommand.php
+++ b/src/Command/InstallPackageCommand.php
@@ -189,11 +189,10 @@ class InstallPackageCommand extends BaseCommand
         // when we got a match (non 404), extract package information
         if (!$response->isError()) {
 
-            $foundPkg = simplexml_load_string ($response->response);
+            $foundPkg = simplexml_load_string($response->response);
 
             // no matches, skip empty package name
-            if ($foundPkg['total'] > 0) {
-
+            if ($foundPkg) {
                 $packages[strtolower((string) $foundPkg->name)] = array (
                     'name' => (string) $foundPkg->name,
                     'version' => (string) $foundPkg->version,


### PR DESCRIPTION
### What does it do ?
This ensures the latest package version is always downloaded if multiple versions are available. As far as I could test, the correct package is always on top of the list in the response, so I think using the first result is reliable.

I don't really know how that list is being sorted though, so just to be sure it also checks if the package name is present in the signature. This means it always returns 1 package, so I disabled the "(x) packages found" message in the console output.

I also noticed an incorrect variable name on line 195. Well.. PhpStorm did ;) That suggests that the direct match was never working in the first place and it always fell back on the query straightaway.

Fixing that seems to make it possible (again?) to define the exact package version in .gitify and prevent updating to a newer version when re-running package:install --all.

### Why is it needed ?
My initial issue was that Redactor now offers 2 versions through the ModMore package provider and it always installs the last one in the array (which is the lower version). Now it installs Redactor 3 when using 'redactor' in config. Ideally, you could specify an older version in the config file if you don't want to upgrade to v3, but somehow for the ModMore provider I can't get this to work..

In addition, Gitify often starts installing incorrect and unrelated packages when the package could not be found. This is annoying and shouldn't be the case. It should look for 1 package only and return either the latest version (formit) or a specific version (formit-4.2.0-pl). Otherwise an error that no match was found.

### Related issue(s)/PR(s)
https://github.com/modmore/Gitify/issues/262

And for anyone also unable to install colorpicker with Gitify, that should work now too. There seems to be a glitch in that package with minor version not set.