### PR TITLE
Safely backup in path with spaces

### DIFF
--- a/src/Command/BackupCommand.php
+++ b/src/Command/BackupCommand.php
@@ -112,7 +112,7 @@ class BackupCommand extends BaseCommand
             $password_parameter = "-p'{$database_password}'";
         }
 
-        exec("mysqldump -u {$database_user} {$password_parameter} -h {$database_server} {$dbase} > {$targetFile} ");
+        exec("mysqldump -u {$database_user} {$password_parameter} -h {$database_server} {$dbase} > \"{$targetFile}\" ");
         return 0;
     }
 }


### PR DESCRIPTION
### What does it do ?
Add double quotes around {$targetFile}.

### Why is it needed ?
Gitify backup needs to reliably work even in paths with spaces. 

### Related issue(s)/PR(s)
Fix #313 
Fix #172 
