### PR TITLE
Add command to *only* download and extract MODX

### DIFF
--- a/application.php
+++ b/application.php
@@ -61,6 +61,7 @@ if (!defined('GITIFY_CACHE_DIR')) {
 use modmore\Gitify\Command\BackupCommand;
 use modmore\Gitify\Command\BuildCommand;
 use modmore\Gitify\Command\ClearCacheCommand;
+use modmore\Gitify\Command\DownloadModxCommand;
 use modmore\Gitify\Command\ExtractCommand;
 use modmore\Gitify\Command\InitCommand;
 use modmore\Gitify\Command\InstallModxCommand;
@@ -76,6 +77,7 @@ $version = $composerData['version'];
 $application = new Gitify('Gitify', $version);
 $application->add(new InitCommand);
 $application->add(new BuildCommand);
+$application->add(new DownloadModxCommand);
 $application->add(new ExtractCommand);
 $application->add(new InstallModxCommand);
 $application->add(new UpgradeModxCommand);

--- a/src/Command/DownloadModxCommand.php
+++ b/src/Command/DownloadModxCommand.php
@@ -1,0 +1,65 @@
+<?php
+namespace modmore\Gitify\Command;
+
+use modmore\Gitify\BaseCommand;
+use modmore\Gitify\Mixins\DownloadModx;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Class DownloadModxCommand
+ *
+ * Download a clean version of MODX.
+ *
+ * @package modmore\Gitify\Command
+ */
+class DownloadModxCommand extends BaseCommand
+{
+    use DownloadModx;
+
+    public $loadConfig = false;
+    public $loadMODX = false;
+
+    protected function configure()
+    {
+        $this
+            ->setName('modx:download')
+            ->setDescription('Downloads a fresh MODX installation.')
+            ->addArgument(
+                'version',
+                InputArgument::OPTIONAL,
+                'The version of MODX to download, in the format 2.3.2-pl. Leave empty or specify "latest" to download the last stable release.',
+                'latest'
+            )
+            ->addOption(
+                'download',
+                'd',
+                InputOption::VALUE_NONE,
+                'Force download the MODX package even if it already exists in the cache folder.'
+            );
+    }
+
+    /**
+     * Runs the command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $version = $this->input->getArgument('version');
+        $forced = $this->input->getOption('download');
+
+        if (!$this->getMODX($version, $forced)) {
+            return 1; // exit
+        }
+
+        $output->writeln('Done! ' . $this->getRunStats());
+        return 0;
+    }
+
+}


### PR DESCRIPTION
### What does it do ?
Adds a command to only download and extract MODX

### Why is it needed ?
Sometimes we don't want to run setup, e.g in custom deploy tools.

### Related issue(s)/PR(s)
none