### PR TITLE
Fix package download on exact match results

### DIFF
--- a/src/Command/InstallPackageCommand.php
+++ b/src/Command/InstallPackageCommand.php
@@ -192,7 +192,7 @@ class InstallPackageCommand extends BaseCommand
             $foundPkg = simplexml_load_string ( $response->response );
 
             // no matches, skip empty package name
-            if ($foundPackages['total'] > 0) {
+            if (!is_array($foundPkg['package'])) {
 
               $packages [strtolower((string) $foundPkg->name)] = array (
                   'name' => (string) $foundPkg->name,


### PR DESCRIPTION
### What does it do ?
Fix package download on exact match results. 

### Why is it needed ?
If there is a match there is no total property, this would cause the exact match package to be "ignored" and download the wrong package down the road.

### Related issue(s)/PR(s)
none?
