### PR TITLE
Complementary fix of #356

### DIFF
--- a/src/Gitify.php
+++ b/src/Gitify.php
@@ -2,6 +2,7 @@
 
 namespace modmore\Gitify;
 
+use Kbjr\Git\Git;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -110,10 +111,10 @@ class Gitify extends Application
             if (!$this->repository) {
                 $gitPath = self::loadMODX()->getOption('gitify.git_path', null, '/usr/bin/git');
                 if (!empty($gitPath)) {
-                    \Git::set_bin($gitPath);
+                    Git::setBin($gitPath);
                 }
                 $repositoryPath = self::loadMODX()->getOption('gitify.repository_path', null, MODX_BASE_PATH, true);
-                $this->repository = \Git::open($repositoryPath);
+                $this->repository = Git::open($repositoryPath);
             }
         } catch (\Exception $e) {
             return $e->getMessage();


### PR DESCRIPTION
### What does it do ?
The PR that was made in [kbjr/Git.php](https://github.com/kbjr/Git.php/pull/65) also changed the name of the methods on the `GitRepo` class. 

This PR fix that issue

### Why is it needed ?
I'm not familiar with this package but if the method `modmore\Gitify::getRepository()` gets call it will fail since now the `Git` class needs to be included with its full namespace and also the name of the methods are now camel case. 

### Related issue(s)/PR(s)
This is a complementary fix of #356 
