### PR TITLE
bugfix: mysql command doesnt work with spaces #363

### DIFF
--- a/src/Command/RestoreCommand.php
+++ b/src/Command/RestoreCommand.php
@@ -132,7 +132,7 @@ class RestoreCommand extends BaseCommand
         $output->writeln('Restoring from backup <info>' . $file . '</info>...');
 
         $database_password = str_replace("'", '\'', $database_password);
-        exec("mysql -u {$database_user} -p'{$database_password}' -h {$database_server} {$dbase} < {$targetDirectory}{$file}");
+        exec("mysql -u {$database_user} -p'{$database_password}' -h {$database_server} {$dbase} < \"{$targetDirectory}{$file}\" ");
         return 0;
     }
 }


### PR DESCRIPTION
### What does it do ?

Gitify restore now works also with spaces in path.

### Related issue(s)/PR(s)

https://github.com/modmore/Gitify/issues/363