### PR TITLE
Properly compare multiple package versions

### DIFF
--- a/src/Command/InstallPackageCommand.php
+++ b/src/Command/InstallPackageCommand.php
@@ -378,7 +378,7 @@ class InstallPackageCommand extends BaseCommand
                             $latest = $version;
                         } else {
                             // Replace latest version with current one if it's higher
-                            if (version_compare($version, $latest) == 1) {
+                            if (version_compare($version, $latest, '>=')) {
                                 $latest = $version;
                             }
                         }

--- a/src/Command/InstallPackageCommand.php
+++ b/src/Command/InstallPackageCommand.php
@@ -356,7 +356,7 @@ class InstallPackageCommand extends BaseCommand
                             'location' => (string) $foundPkg->location,
                             'signature' => (string) $foundPkg->signature
                         );
-                        $packageVersions[(string)$foundPkg->version] = [
+                        $packageVersions[(string)$foundPkg->signature] = [
                             'name' => (string) $foundPkg->name,
                             'version' => (string) $foundPkg->version,
                             'release' => (string) $foundPkg->release,
@@ -368,8 +368,25 @@ class InstallPackageCommand extends BaseCommand
 
                 // If there are multiple versions of the same package, use the latest
                 if (count($packageVersions) > 1) {
-                    $packageLatest = max(array_keys($packageVersions));
-                    $packages[$packageName] = $packageVersions[$packageLatest];
+                    $i = 0;
+                    $latest = '';
+
+                    // Compare versions
+                    foreach (array_keys($packageVersions) as $version) {
+                        if ($i == 0) {
+                            // First iteration
+                            $latest = $version;
+                        } else {
+                            // Replace latest version with current one if it's higher
+                            if (version_compare($version, $latest) == 1) {
+                                $latest = $version;
+                            }
+                        }
+                        $i++;
+                    }
+
+                    // Use latest
+                    $packages[$packageName] = $packageVersions[$latest];
                 }
 
                 // If there's still no match, revisit the response and just grab all hits...


### PR DESCRIPTION
### What does it do ?

Fix a silly mistake.

### Why is it needed ?

I assumed that the max() function was able to figure out the highest semantic version number, but of course it's not that easy. Gitify selected 1.9.0 instead of 1.11.1 in my latest test, so apparently 1.9 was seen as higher than 1.1.

So the whole semantic version string needs to be picked apart and compared. Fortunately there's a version_compare function available in PHP that does just that, so it's now able to sniff out the actual latest version from the packageVersions array. Regardless of position. It even evaluates -alpha and -beta suffixes, so those should be correctly evaluated now too! They did for me with a test array.

### Related issue(s)/PR(s)

https://github.com/modmore/Gitify/pull/327
