### PR TITLE
trigger MODX into setup mode during build

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -282,6 +282,7 @@ class BuildCommand extends BaseCommand
      * @param bool $isConflictResolution
      */
     public function buildSingleResource($data, $isConflictResolution = false) {
+	$this->modx->setOption(\xPDO::OPT_SETUP, true);
         // Figure out the primary key - it's either uri or id in the case of a resource.
         if (!empty($data['uri'])) {
             $primary = array('uri' => $data['uri'], 'context_key' => $data['context_key']);
@@ -443,6 +444,7 @@ class BuildCommand extends BaseCommand
      * @param bool $isConflictResolution
      */
     public function buildSingleObject($data, $type, $isConflictResolution = false) {
+	$this->modx->setOption(\xPDO::OPT_SETUP, true);
         $primaryKey = !empty($type['primary']) ? $type['primary'] : 'id';
         $class = $type['class'];
 


### PR DESCRIPTION
### What does it do ?
Trigger MODX into setup mode during build.

### Why is it needed ?
Current method conflicts with MODX Cloud's Backstage. We are testing against Setup mode for things like Teleport and MODX upgrades to prevent unnecessary firing / tracking. 

