### PR TITLE
Bug Fix for: gitify clearcache

### DIFF
--- a/src/Command/ClearCacheCommand.php
+++ b/src/Command/ClearCacheCommand.php
@@ -24,5 +24,7 @@ class ClearCacheCommand extends BaseCommand
             exec("rm -rf " . GITIFY_CACHE_DIR);
             $output->writeln('Cleared the Gitify cache.');
         }
+        
+        return 0;
     }
 }


### PR DESCRIPTION
### What does it do ?
Fix is just adding a simple `return 0;` to the ClearCacheCommand->execute() method;

### Why is it needed ?
BUG: 
Fatal error: Uncaught TypeError: Return value of "modmore\Gitify\Command\ClearCacheCommand::execute()" must be of the type int, "null" returned. in /core/vendor/symfony/console/Command/Command.php:301

### Related issue(s)/PR(s)
Let us know if this is related to any issue/pull request 
N/A
