### PR TITLE
Added ability to limit number of extracted records

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -201,6 +201,9 @@ class ExtractCommand extends BaseCommand
         if (!empty($criteria)) {
             $c->where(array($criteria));
         }
+        if (isset($options['limit']) && is_int($options['limit'])) {
+            $c->limit($options['limit']);
+        }
         $collection = $this->modx->getCollection($options['class'], $c);
 
         $this->modx->getCacheManager();


### PR DESCRIPTION
### What does it do ?
Introduced a new `limit` option (only used on extract) to... limit the number of extracted records

### Why is it needed ?
We are having large projects were all the records are not needed (ie. all blog entries) but only a subset for testing/development purpose. With that limit option, we can safely extract only x records.

### Related issue(s)/PR(s)
None found
