### PR TITLE
FIX: build command removes some files and modx objects

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -594,14 +594,14 @@ class BuildCommand extends BaseCommand
             $runExtract = false;
             foreach ($this->conflictingObjects as $conflict) {
                 $showOriginalPrimary = is_array($conflict['existing_object_primary']) ? json_encode($conflict['existing_object_primary']) : $conflict['existing_object_primary'];
-                $this->output->writeln('- Attempting to resolve ID Conflict for <comment>' . $showOriginalPrimary . '</comment> with <comment>' . count($conflict['conflicts']) . '</comment> duplicate(s).');
-
-
+                
                 // Get the original/master copy of this conflict
-                $getPrimary = $conflict['existing_object_primary'];
+                $getPrimary = $conflict['object_id'];
                 if (!is_array($getPrimary)) {
                     $getPrimary = array('id' => $getPrimary);
                 }
+                $this->output->writeln('- Attempting to resolve ID Conflict for <comment>' . $showOriginalPrimary . ' (ID: '.$getPrimary["id"].')</comment> with <comment>' . count($conflict['conflicts']) . '</comment> duplicate(s).');
+
                 $original = $this->modx->getObject($type['class'], $getPrimary);
                 if ($original instanceof \xPDOObject) {
                     // Get the primary key definition of the class
@@ -694,6 +694,7 @@ class BuildCommand extends BaseCommand
         if (!isset($this->conflictingObjects[$internalPrimary])) {
             $this->conflictingObjects[$internalPrimary] = array(
                 'existing_object_primary' => $primary,
+                'object_id' => $internalPrimary,
                 'conflicts' => array(),
             );
         }

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -168,7 +168,7 @@ class BuildCommand extends BaseCommand
         $directory = new \DirectoryIterator($folder);
         foreach ($directory as $path => $info) {
             /** @var \SplFileInfo $info */
-            $name = $info->getBasename();
+            $name = $info->getFilename();
 
             // Ignore dotfiles/folders
             if (substr($name, 0, 1) == '.') continue;
@@ -228,7 +228,7 @@ class BuildCommand extends BaseCommand
         $resources = array();
         $parents = array();
         foreach ($iterator as $fileInfo) {
-            if (substr($fileInfo->getBasename(), 0, 1) == '.') {
+            if (substr($fileInfo->getFilename(), 0, 1) == '.') {
                 continue;
             }
             /** @var \SplFileInfo $fileInfo */
@@ -258,7 +258,7 @@ class BuildCommand extends BaseCommand
             try {
                 $data = Gitify::fromYAML($rawData);
             } catch (ParseException $Exception) {
-                $this->output->writeln('<error>Could not parse ' . $resource->getBasename() . ': ' . $Exception->getMessage() .'</error>');
+                $this->output->writeln('<error>Could not parse ' . $resource->getFilename() . ': ' . $Exception->getMessage() .'</error>');
                 continue;
             }
             if (!empty($content)) {
@@ -397,7 +397,7 @@ class BuildCommand extends BaseCommand
 
         foreach ($directory as $file) {
             /** @var \SplFileInfo $file */
-            $name = $file->getBasename();
+            $name = $file->getFilename();
 
             // Ignore dotfiles/folders
             if (substr($name, 0, 1) == '.') continue;

--- a/src/Command/RestoreCommand.php
+++ b/src/Command/RestoreCommand.php
@@ -77,7 +77,7 @@ class RestoreCommand extends BaseCommand
         $directory = new \DirectoryIterator($targetDirectory);
         foreach ($directory as $path => $info) {
             /** @var \SplFileInfo $info */
-            $name = $info->getBasename();
+            $name = $info->getFilename();
             // Ignore dotfiles/folders
             if (substr($name, 0, 1) === '.') {
                 continue;


### PR DESCRIPTION
### What does it do ?
replaced SplFileInfo::getBasename() calls with SplFileInfo::getFilename(), also second commit fixes conflict resolution

### Why is it needed ?
1. If yaml file name starts with non-english characters, `gitify build` removed those files.

#### Example:
```
$file = new SplFileInfo("directory/файл.txt"); // file, which contains cyrillic characters
var_dump($file->getBasename());
var_dump($file->getFilename());
```
output:
```
string(4) ".txt" // wrong
string(12) "файл.txt" // correct

```
2. Fixes primary key conflict resolution (see comment below)