### PR TITLE
Force rebuilding namespaces after building namespaces on Revo 3

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -434,6 +434,14 @@ class BuildCommand extends BaseCommand
         $this->removeOrphans($type);
 
         $this->resolveConflicts($folder, $type);
+
+        if (
+            class_exists('\modX\Revolution\modNamespace') &&
+            in_array($type['class'], ['modNamespace', '\modNamespace', '\modX\Revolution\modNamespace'], true)
+        ) {
+            $this->modx->getCacheManager()-> generateNamespacesCache('namespaces');
+            \modX\Revolution\modNamespace::loadCache($this->modx);
+        }
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

Rebuild MODX namespace cache after seeding namespaces

### Why is it needed ?

Because of how Revo 3 "autoloads" from namespaces (bootstrap.php) namespace cache needs to be force rebuilt.
