### PR TITLE
Always unset content for static elements

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -285,6 +285,7 @@ class ExtractCommand extends BaseCommand
             $content = $object->getContent();
 
             if (!empty($content)) {
+                unset($data['content']);
                 foreach ($data as $key => $value) {
                     if ($value === $content) unset($data[$key]);
                 }


### PR DESCRIPTION
### What does it do ?

Always unset the "content" attribute on static elements, so that only the content added at the bottom is used

### Why is it needed ?

We had issues where every extract the `content` attribute of a static template was either removed, or added back.
Always removing the attribute felt like acceptable as the content is always populated from the bottom of the yaml file
