### PR TITLE
Fix undefined array key "service" warnings

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -209,12 +209,12 @@ class BuildCommand extends BaseCommand
             $path .= 'model/';
         }
 
-        if ($options['service']) {
+        if (isset($options['service'])) {
             $path .= $package . '/';
             $this->modx->getService($package, $options['service'], $path);
-	} else {
-	    $this->modx->addPackage($package, $path);
-	}
+        } else {
+            $this->modx->addPackage($package, $path);
+        }
     }
 
     /**

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -323,12 +323,12 @@ class ExtractCommand extends BaseCommand
             $path .= 'model/';
         }
 
-	if ($options['service']) {
-	    $path .= $package . '/';
-	    $this->modx->getService($package, $options['service'], $path);
-	} else {
-	    $this->modx->addPackage($package, $path);
-	}
+        if (isset($options['service'])) {
+            $path .= $package . '/';
+            $this->modx->getService($package, $options['service'], $path);
+        } else {
+            $this->modx->addPackage($package, $path);
+        }
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

It checks if "service" array key is set.

### Why is it needed ?

PHP 8 has become more strict with this kind of loosy truthy falsy check on an array key.

### Related issue(s)/PR(s)

Fixes #426
