### PR TITLE
Automatically update the list of packages with versions during extract + improve install

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -9,8 +9,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use xPDO\xPDOIterator;
-use Symfony\Component\Yaml\Exception\ParseException;
-use Symfony\Component\Yaml\Yaml;
 use xPDOTransport;
 
 /**

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -519,7 +519,7 @@ class ExtractCommand extends BaseCommand
         return \modResource::filterPathSegment($this->modx, $path, $options);
     }
 
-    private function extractPackages($file = null): void
+    private function extractPackages(string $file = null): void
     {
         $this->output->writeln('<info>Extracting installed packages...</info>');
         $data = Gitify::loadConfig($file);

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -91,7 +91,7 @@ class ExtractCommand extends BaseCommand
         }
 
         if ($input->getOption('packages')) {
-            $this->extractPackages();
+            $this->extractPackages($input->getOption('config'));
         }
 
         $output->writeln('Done! ' . $this->getRunStats());
@@ -519,11 +519,11 @@ class ExtractCommand extends BaseCommand
         return \modResource::filterPathSegment($this->modx, $path, $options);
     }
 
-    private function extractPackages(): void
+    private function extractPackages($file = null): void
     {
         $this->output->writeln('<info>Extracting installed packages...</info>');
-        $file = GITIFY_WORKING_DIR . '.gitify';
-        $data = Yaml::parseFile($file);
+        $data = Gitify::loadConfig($file);
+        $file = GITIFY_WORKING_DIR . $file;
 
         $result = $this->modx->call('transport.modTransportPackage', 'listPackages', [
             &$this->modx,

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -3,10 +3,15 @@ namespace modmore\Gitify\Command;
 
 use modmore\Gitify\BaseCommand;
 use modmore\Gitify\Gitify;
+use modTransportPackage;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use xPDO\xPDOIterator;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+use xPDOTransport;
 
 /**
  * Class BuildCommand
@@ -32,6 +37,13 @@ class ExtractCommand extends BaseCommand
                 'partitions',
                 InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
                 'Specify the data partition key (folder name), or keys separated by a space, that you want to extract. '
+            )
+            ->addOption(
+                'packages',
+                'p',
+                InputOption::VALUE_NEGATABLE,
+                'Skip extracting installed package when set.',
+                true
             )
         ;
     }
@@ -76,6 +88,10 @@ class ExtractCommand extends BaseCommand
 
                     break;
             }
+        }
+
+        if ($input->getOption('packages')) {
+            $this->extractPackages();
         }
 
         $output->writeln('Done! ' . $this->getRunStats());
@@ -501,5 +517,56 @@ class ExtractCommand extends BaseCommand
             return $this->_resource->cleanAlias($path, $options);
         }
         return \modResource::filterPathSegment($this->modx, $path, $options);
+    }
+
+    private function extractPackages(): void
+    {
+        $this->output->writeln('<info>Extracting installed packages...</info>');
+        $file = GITIFY_WORKING_DIR . '.gitify';
+        $data = Yaml::parseFile($file);
+
+        $result = $this->modx->call('transport.modTransportPackage', 'listPackages', [
+            &$this->modx,
+            1,
+            0,
+            0,
+            ''
+        ]);
+
+        $providers = [];
+        /** @var modTransportPackage $package */
+        foreach ($result['collection'] as $package) {
+            $signature = $package->get('signature');
+            $sig = xPDOTransport::parseSignature($signature);
+
+            if (!$provider = $package->getOne('Provider')) {
+                $this->output->writeln("- <comment>Package {$sig[0]} is not assigned to a provider, skipping</comment>");
+                continue;
+            }
+
+            $providerKey = $provider->get('name');
+            if (!isset($providers[$providerKey])) {
+                $providers[$providerKey] = [
+                    'service_url' => $provider->get('service_url')
+                ];
+                if ($provider->get('description')) {
+                    $providers[$providerKey]['description'] = $provider->get('description');
+                }
+                if ($provider->get('username')) {
+                    $providers[$providerKey]['username'] = $provider->get('username');
+                }
+                if ($provider->get('api_key') && !file_exists(GITIFY_WORKING_DIR . '.' . $providerKey . '.key')) {
+                    $key = $provider->get('api_key');
+                    file_put_contents(GITIFY_WORKING_DIR . '.' . $providerKey . '.key', $key);
+                    $providers[$providerKey]['api_key'] = '.' . $providerKey . '.key';
+                }
+            }
+
+            $providers[$providerKey]['packages'][] = $signature;
+        }
+        $data['packages'] = $providers;
+
+        file_put_contents($file, Gitify::toYAML($data));
+        $this->output->writeln('<info>Packages updated.</info>');
     }
 }


### PR DESCRIPTION
### What does it do ?

By default, update the .gitify file with installed packages and provider information when extracting. This makes it so the list of packages should be up-to-date. This can be opted out of with `--no-packages`. 

Also update the `package:install` command to skip installing if an exact version match or a higher version of a package is already installed. This speeds it up _a lot_ when there is nothing to update.

### Why is it needed ?

Package support is kinda flaky in Gitify. This helps make a more complete workflow possible.  

### Related issue(s)/PR(s)
#157
#357 
#262 
Fixes #108 

There are a couple of outstanding PRs that might conflict with this. I'd suggest sorting those out first, and then I'll happily update this one.

Specifically, #417 adds the ability to use a different config file, so this will need to be updated to write to the provided config file instead of the hardcoded one.