### PR TITLE
Fixed non english file names generation

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -168,7 +168,7 @@ class BuildCommand extends BaseCommand
         $directory = new \DirectoryIterator($folder);
         foreach ($directory as $path => $info) {
             /** @var \SplFileInfo $info */
-            $name = $info->getBasename();
+            $name = $info->getFilename();
 
             // Ignore dotfiles/folders
             if (substr($name, 0, 1) == '.') continue;
@@ -228,7 +228,7 @@ class BuildCommand extends BaseCommand
         $resources = array();
         $parents = array();
         foreach ($iterator as $fileInfo) {
-            if (substr($fileInfo->getBasename(), 0, 1) == '.') {
+            if (substr($fileInfo->getFilename(), 0, 1) == '.') {
                 continue;
             }
             /** @var \SplFileInfo $fileInfo */
@@ -258,7 +258,7 @@ class BuildCommand extends BaseCommand
             try {
                 $data = Gitify::fromYAML($rawData);
             } catch (ParseException $Exception) {
-                $this->output->writeln('<error>Could not parse ' . $resource->getBasename() . ': ' . $Exception->getMessage() .'</error>');
+                $this->output->writeln('<error>Could not parse ' . $resource->getFilename() . ': ' . $Exception->getMessage() .'</error>');
                 continue;
             }
             if (!empty($content)) {
@@ -397,7 +397,7 @@ class BuildCommand extends BaseCommand
 
         foreach ($directory as $file) {
             /** @var \SplFileInfo $file */
-            $name = $file->getBasename();
+            $name = $file->getFilename();
 
             // Ignore dotfiles/folders
             if (substr($name, 0, 1) == '.') continue;

--- a/src/Command/RestoreCommand.php
+++ b/src/Command/RestoreCommand.php
@@ -77,7 +77,7 @@ class RestoreCommand extends BaseCommand
         $directory = new \DirectoryIterator($targetDirectory);
         foreach ($directory as $path => $info) {
             /** @var \SplFileInfo $info */
-            $name = $info->getBasename();
+            $name = $info->getFilename();
             // Ignore dotfiles/folders
             if (substr($name, 0, 1) === '.') {
                 continue;


### PR DESCRIPTION
### What does it do ?
replaced SplFileInfo::getBasename() calls with SplFileInfo::getFilename()

### Why is it needed ?
1. If yaml file name starts with non-english characters, `gitify build` removed those files.

#### Example:
```
$file = new SplFileInfo("directory/файл.txt"); // file, which contains cyrillic characters
var_dump($file->getBasename());
var_dump($file->getFilename());
```
output:
```
string(4) ".txt" // wrong
string(12) "файл.txt" // correct

```

Related issue: https://github.com/modmore/Gitify/issues/188