### PR TITLE
Prevent category names in elements extract

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -485,7 +485,6 @@ class ExtractCommand extends BaseCommand
                 }
                 break;
         }
-        }
 
         return $data;
     }

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -475,13 +475,16 @@ class ExtractCommand extends BaseCommand
                 ksort($tvs);
                 $data['tvs'] = $tvs;
                 break;
-
+            
             // Handle string-based categories automagically on elements
             case $object instanceof \modElement && !($object instanceof \modCategory):
-                if (isset($data['category']) && !empty($data['category']) && is_numeric($data['category'])) {
-                    $data['category'] = $this->getCategoryName($data['category']);
+                if (isset($this->config['category_names_in_elements']) && $this->config['category_names_in_elements'] === true) {
+                    if (!empty($data['category']) && is_numeric($data['category'])) {
+                        $data['category'] = $this->getCategoryName($data['category']);
+                    }
                 }
                 break;
+        }
         }
 
         return $data;

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -478,7 +478,7 @@ class ExtractCommand extends BaseCommand
             
             // Handle string-based categories automagically on elements
             case $object instanceof \modElement && !($object instanceof \modCategory):
-                if (isset($this->config['category_names_in_elements']) && $this->config['category_names_in_elements'] === true) {
+                if (!(isset($this->config['category_ids_in_elements']) && $this->config['category_ids_in_elements'] === true)) {
                     if (!empty($data['category']) && is_numeric($data['category'])) {
                         $data['category'] = $this->getCategoryName($data['category']);
                     }


### PR DESCRIPTION
### What does it do ?
Do not extract category names into elements any more, instead keep the ids. In order to not introduce a BC suddenly to existing installations, adds a config option `category_ids_in_elements` which needs to be set to true in .gitify file to activate ids in favor of names.

### Why is it needed ?
There are problems when categories have the same names.  

### Related issue(s)/PR(s)
I see that just as an intermediate solution - i prefer having https://github.com/modmore/Gitify/issues/165 being implemented, as this would give much more file "overview" in larger projects and reflect the tree like structure in the manager better (same as with resources/content, which is already extracted into folders)
