### PR TITLE
Accept packages with new structure using xpdo3

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -136,4 +136,36 @@ abstract class BaseCommand extends Command
 
         return null;
     }
+
+    /**
+     * Loads a package (xPDO Model) by its name
+     *
+     * @param $package
+     * @param array $options
+     */
+    public function getPackage($package, array $options = []): void
+    {
+        // Check if this package is specified to use the newer xPDO v3 namespaced model structure
+        $xpdo3 = !empty($options['namespace']);
+
+        $path = (isset($options['package_path'])) ? $options['package_path'] : false;
+        if (!$path) {
+            $path = $this->modx->getOption($package . '.core_path', null, $this->modx->getOption('core_path') . 'components/' . $package . '/', true);
+            $path .= $xpdo3 ? 'src/' : 'model/';
+        }
+
+        // If the package uses the xPDO v3 namespaced model structure, add package with namespace and model options.
+        if ($xpdo3) {
+            $this->modx->addPackage($options['model'], $path, null, $options['namespace'] . '\\');
+            return;
+        }
+
+        // Load packages using the older model structure
+        if (isset($options['service'])) {
+            $path .= $package . '/';
+            $this->modx->getService($package, $options['service'], $path);
+        } else {
+            $this->modx->addPackage($package, $path);
+        }
+    }
 }

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -196,28 +196,6 @@ class BuildCommand extends BaseCommand
     }
 
     /**
-     * Loads a package (xPDO Model) by its name
-     *
-     * @param $package
-     * @param array $options
-     */
-    public function getPackage($package, array $options = array())
-    {
-        $path = (isset($options['package_path'])) ? $options['package_path'] : false;
-        if (!$path) {
-            $path = $this->modx->getOption($package . '.core_path', null, $this->modx->getOption('core_path') . 'components/' . $package . '/', true);
-            $path .= 'model/';
-        }
-
-        if (isset($options['service'])) {
-            $path .= $package . '/';
-            $this->modx->getService($package, $options['service'], $path);
-        } else {
-            $this->modx->addPackage($package, $path);
-        }
-    }
-
-    /**
      * Loops over resource files to create the resources.
      *
      * @param $context

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -380,38 +380,6 @@ class ExtractCommand extends BaseCommand
     }
 
     /**
-     * Loads a package (xPDO Model) by its name
-     *
-     * @param $package
-     * @param array $options
-     */
-    public function getPackage($package, array $options = []): void
-    {
-        // Check if this package is specified to use the newer xPDO v3 namespaced model structure
-        $xpdo3 = !empty($options['namespace']);
-
-        $path = (isset($options['package_path'])) ? $options['package_path'] : false;
-        if (!$path) {
-            $path = $this->modx->getOption($package . '.core_path', null, $this->modx->getOption('core_path') . 'components/' . $package . '/', true);
-            $path .= $xpdo3 ? 'src/' : 'model/';
-        }
-
-        // If the package uses the xPDO v3 namespaced model structure, add package with namespace and model options.
-        if ($xpdo3) {
-            $this->modx->addPackage($options['model'], $path, null, $options['namespace'] . '\\');
-            return;
-        }
-
-        // Load packages using the older model structure
-        if (isset($options['service'])) {
-            $path .= $package . '/';
-            $this->modx->getService($package, $options['service'], $path);
-        } else {
-            $this->modx->addPackage($package, $path);
-        }
-    }
-
-    /**
      * Loops over a folder to get all the files in it. Uses for cleaning up old files.
      *
      * @param $folder

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -385,12 +385,21 @@ class ExtractCommand extends BaseCommand
      * @param $package
      * @param array $options
      */
-    public function getPackage($package, array $options = array())
+    public function getPackage($package, array $options = []): void
     {
+        // Check if this package is specified to use the xPDO v3 model structure
+        $xpdo3 = !empty($options['xpdo3']) && $options['xpdo3'];
+
         $path = (isset($options['package_path'])) ? $options['package_path'] : false;
         if (!$path) {
             $path = $this->modx->getOption($package . '.core_path', null, $this->modx->getOption('core_path') . 'components/' . $package . '/', true);
-            $path .= 'model/';
+            $path .= $xpdo3 ? 'src/' : 'model/';
+        }
+
+        // If the package uses the xPDO v3 model structure, add package with namespace and model options.
+        if ($xpdo3) {
+            $this->modx->addPackage($options['model'], $path, null, $options['namespace'] . '\\');
+            return;
         }
 
         if (isset($options['service'])) {

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -387,8 +387,8 @@ class ExtractCommand extends BaseCommand
      */
     public function getPackage($package, array $options = []): void
     {
-        // Check if this package is specified to use the xPDO v3 model structure
-        $xpdo3 = !empty($options['xpdo3']) && $options['xpdo3'];
+        // Check if this package is specified to use the newer xPDO v3 namespaced model structure
+        $xpdo3 = !empty($options['namespace']);
 
         $path = (isset($options['package_path'])) ? $options['package_path'] : false;
         if (!$path) {
@@ -396,12 +396,13 @@ class ExtractCommand extends BaseCommand
             $path .= $xpdo3 ? 'src/' : 'model/';
         }
 
-        // If the package uses the xPDO v3 model structure, add package with namespace and model options.
+        // If the package uses the xPDO v3 namespaced model structure, add package with namespace and model options.
         if ($xpdo3) {
             $this->modx->addPackage($options['model'], $path, null, $options['namespace'] . '\\');
             return;
         }
 
+        // Load packages using the older model structure
         if (isset($options['service'])) {
             $path .= $package . '/';
             $this->modx->getService($package, $options['service'], $path);


### PR DESCRIPTION
Using the new xPDO v3 style package structure relies on using the new options:
- `namespace`
- `model`

And `class` should be changed to the fully qualified class name.

As an example for `CollectionSetting` in the package Collections, you'd use the following:
```
collections_settings:
        namespace: Collections
        model: Collections\Model
        class: Collections\Model\CollectionSetting
        primary: id
        package: collections
```

You can also specify a custom path as before using `package_path`. Otherwise the new default will be used. The new default is `src` instead of `model`.
e.g. 
```
core/components/package/src/
```