### PR TITLE
add option "--ignoretables" to BackupCommand.php

### DIFF
--- a/src/Command/BackupCommand.php
+++ b/src/Command/BackupCommand.php
@@ -50,6 +50,12 @@ class BackupCommand extends BaseCommand
                 'c',
                 InputOption::VALUE_NONE,
                 'When specified, resulting backup file will be gzip compressed.'
+            )            
+            ->addOption(
+                'ignoretables',
+                'ignore',
+                InputArgument::OPTIONAL,
+                'When specified, the tables are ignored. Separate multiple tables with commas.'
             );
     }
 
@@ -132,9 +138,18 @@ class BackupCommand extends BaseCommand
 
         $tablespaces = $input->getOption('no-tablespaces') ? ' --no-tablespaces' : '';
         $gzip = $input->getOption('compress') ? '| gzip - ' : '';
-
-        exec("mysqldump{$tablespaces} -u {$database_user} {$password_parameter} -h {$database_server} {$dbase} {$gzip}> {$targetFile} ");
-
+        
+        $ignoretables = $input->getOption('ignoretables');
+        $ignoretables_parameter = '';
+        if ($ignoretables) {
+            $ignoretables_parameters = [];
+            foreach (explode(',', $ignoretables) as $tablename) {
+                $ignoretables_parameters[] = '--ignore-table=' . $dbase . '.' . $tablename;
+            }
+            $ignoretables_parameter = implode(' ', $ignoretables_parameters);
+        }
+        
+        exec("mysqldump{$tablespaces} -u {$database_user} {$password_parameter} -h {$database_server} {$dbase} {$ignoretables_parameter} {$gzip}> {$targetFile} ");
 
         return 0;
     }


### PR DESCRIPTION
### What does it do ?

Add the mysqldump parameter [--ignore-table](https://dev.mysql.com/doc/refman/8.4/en/mysqldump.html#option_mysqldump_ignore-table).

### Why is it needed ?

Sometimes you don't need to backup tables like `modx_context_setting` or something like that. Now you can ignore this table with `gitify backup --ignoretables=modx_context_setting`. I use this to do a local backup and restore to the live server, but don't want the context settings for SmartRouting.