### PR TITLE
fix: modmore\Gitify\Command\ExtractCommand::extractPackages() – Implicitly marking parameter $file as nullable is deprecated

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -497,7 +497,7 @@ class ExtractCommand extends BaseCommand
         return \modResource::filterPathSegment($this->modx, $path, $options);
     }
 
-    private function extractPackages(string $file = null): void
+    private function extractPackages(string|null $file = null): void
     {
         $this->output->writeln('<info>Extracting installed packages...</info>');
         $data = Gitify::loadConfig($file);


### PR DESCRIPTION
Prevents this error when running `gitify extract` on PHP 8.3:

```
Deprecated: modmore\Gitify\Command\ExtractCommand::extractPackages(): Implicitly marking parameter $file as nullable is deprecated, the explicit nullable type must be used instead in /.composer/vendor/modmore/gitify/src/Command/ExtractCommand.php on line 500
```