### PR TITLE
MODX Upgrade: Fix quotes in exec command for customPath when having spaces in absolute filepath

### DIFF
--- a/src/Mixins/DownloadModx.php
+++ b/src/Mixins/DownloadModx.php
@@ -156,7 +156,7 @@ trait DownloadModx
                     }
                     // Copy each dir to path specified in config file then remove that dir from source
                     exec("cp -r $path/$k/* '$customPath'");
-                    exec("rm -rf $path/$k");
+                    exec('rm -rf ' . escapeshellarg("$path/$k"));
                 }
 
                 unlink("$path/config.core.php");

--- a/src/Mixins/DownloadModx.php
+++ b/src/Mixins/DownloadModx.php
@@ -155,7 +155,7 @@ trait DownloadModx
                         unlink("$path/$k/config.core.php");
                     }
                     // Copy each dir to path specified in config file then remove that dir from source
-                    exec("cp -r $path/$k/* $customPath");
+                    exec("cp -r $path/$k/* '$customPath'");
                     exec("rm -rf $path/$k");
                 }
 


### PR DESCRIPTION
The upgrade doesn't work if there is a space in your file path. For example, the following path contains a space: `/Volumes/Macintosh HD/Users/jenswittmann/Sites/…`.